### PR TITLE
Update release workflow to allow pull-requests: write

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+name: Release
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  github-action:
+    uses: cloudposse-github-actions/.github/.github/workflows/shared-release-branches.yml@main
+    secrets: inherit


### PR DESCRIPTION
## what
- Update workflows (`.github/workflows/`) to use `cloudposse-github-actions` org workflows 

## why
- Part of migration GHA to `cloudposse-github-actions` org
